### PR TITLE
Add admin setting to select wp column for username

### DIFF
--- a/js/src/admin/components/WPUsersSettingsModal.js
+++ b/js/src/admin/components/WPUsersSettingsModal.js
@@ -1,4 +1,5 @@
 import SettingsModal from 'flarum/components/SettingsModal';
+import Select from 'flarum/components/Select';
 
 import {ID} from '../../config';
 
@@ -34,7 +35,19 @@ export class WPUsersSettingsModal extends SettingsModal {
 			option('logged_in_key', 'Logged In Key', 'LOGGED_IN_KEY'),
 			option('logged_in_salt', 'Logged In Salt', 'LOGGED_IN_SALT'),
 			option('nonce_key', 'Nonce Key', 'NONCE_KEY'),
-			option('nonce_salt', 'Nonce Salt', 'NONCE_SALT')
+			option('nonce_salt', 'Nonce Salt', 'NONCE_SALT'),
+			m('.Form-group', [
+				<label>Get Username from (<i>Column Name of Wordpress users Table for Username mapping</i>)</label>,
+                Select.component({
+                    options: {
+                        user_login: 'user_login',
+                        user_nicename: 'user_nicename',
+                        display_name: 'display_name',
+                    },
+                    value: setting('username_col')(),
+                    onchange: setting('username_col'),
+                }),
+            ]),
 		];
 	}
 }

--- a/src/Middleware/Authenticate.php
+++ b/src/Middleware/Authenticate.php
@@ -205,7 +205,7 @@ class Authenticate implements Middleware {
 		}
 
 		// Get the Flarum user for the WP user if possible.
-		$actor = Core::ensureUser($wpUser);
+		$actor = Core::ensureUser($wpUser, $this->settings);
 
 		// Update the last seen time on the actor if exists.
 		// Based on AuthenticateWithSession->getActor().


### PR DESCRIPTION
Based on this discussion: #5
I was curious to see how it could be possible to change what name flarum uses for its usernames. It turned out to be quite simple,  thanks to the great and well-commented work by @AlexanderOMara. With a little bit of reading how flarum extension works and installing node.js, I was able to add an Admin setting that allows to select a column from the wordpress users table for the usernames. Fortunately, the wordpress displayname is a column. However, the first or last name is not a column, it is part of the usermeta table, and that's beyond my capabilities for now - I'm a noob in web coding...

![image](https://user-images.githubusercontent.com/15105943/103384338-585f8f80-4af6-11eb-8a32-a6afb97f5d89.png)

I looked into the flarum nickname extension and decided to not use it, for the following reasons:
- The feature to let the user change the nickname in flarum is not wanted (changes should only be made in wordpress)
- Avoid additional/unnecessary dependency
- would need validation according to nickname restrictions set by nickname settings
- If needed, wp-users should provide its own DisplayNameDriver, not difficult to implement

Since this is my first contribution to flarum i'm sure there are better ways to implement this feature. Feel free to improve or choose another way, I hope to learn 😃 