### PR TITLE
Fix for WP usernames with spaces in them

### DIFF
--- a/src/WordPress/WordPress.php
+++ b/src/WordPress/WordPress.php
@@ -338,7 +338,7 @@ class WordPress {
 		}
 
 		// Extract the cookie components.
-		$username = $elements['username'];
+		$username = str_replace('+', ' ', $elements['username'] );
 		$hmac = $elements['hmac'];
 		$token = $elements['token'];
 		$expired = $elements['expiration'];


### PR DESCRIPTION
Fixes #21 Fixes authentication for WP usernames that contains spaces.  In the cookie spaces are URL encoded to + which breaks things.